### PR TITLE
pass client response header iterable to _debug

### DIFF
--- a/gsimporter/client.py
+++ b/gsimporter/client.py
@@ -176,7 +176,8 @@ class _Client(object):
         headers.update(self.headers)
         resp = self.http.request(method, url, body=data, headers=headers, preload_content=False)
         content = resp.read()
-        _debug(resp, content)
+        headers = resp.headers
+        _debug(headers, content)
         if resp.status == 404:
             raise NotFound()
         if resp.status < 200 or resp.status > 299:


### PR DESCRIPTION
Httplib2 response object is an iterable of response headers. Urllib3 changes this and the response headers are only available from `response.headers`. The `_debug` method was written for Httplib2 and expects to be able to check for the `content-type` header in the first argument, so the headers must be passed instead of the response.