### PR TITLE
[Fixes ISSUE #5] unexpected error in Geonode -> SSLError: bad handshake

### DIFF
--- a/gsimporter/api.py
+++ b/gsimporter/api.py
@@ -125,7 +125,7 @@ class _UploadBase(object):
         elif hasattr(self, 'href'):
             _href = urlparse(self.href)
             _url = urlparse(self._getuploader().client.url())
-            return _href._replace(netloc=_url.netloc).geturl()
+            return _href._replace(scheme=_url.scheme, netloc=_url.netloc).geturl()
         else:
             return self._getuploader().client.url()
 
@@ -348,7 +348,7 @@ class Task(_UploadBase):
             client = self._client()
             _progress = urlparse(self.progress)
             _url = urlparse(self._getuploader().client.url())
-            _progress = _progress._replace(netloc=_url.netloc).geturl()
+            _progress = _progress._replace(scheme=_url.scheme, netloc=_url.netloc).geturl()
             headers, response = client._request(_progress)
             unicode_error = False
             try:


### PR DESCRIPTION
Fixes #5 

The URL's `scheme` value should be maintained in addition to the already maintained `netloc` value. Otherwise a server using `https` publicly attempts to use `https` privately regardless of the private URL's original scheme, the opposite would also occur if `http` were being used publicly. 